### PR TITLE
feat: peerDAS - implement distributed blob publishing

### DIFF
--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -4,7 +4,7 @@ import {StrictEventEmitter} from "strict-event-emitter-types";
 import {routes} from "@lodestar/api";
 import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
-import {phase0} from "@lodestar/types";
+import {phase0, fulu, SignedBeaconBlock} from "@lodestar/types";
 
 /**
  * Important chain events that occur during normal chain operation.
@@ -34,6 +34,17 @@ export enum ChainEvent {
    * This event is guaranteed to be triggered whenever the fork choice justified checkpoint is updated. This is in response to a newly processed block.
    */
   forkChoiceFinalized = "forkChoice:finalized",
+
+  /**
+   * This event signals that the chain has processed a data column gossip.
+   */
+  dataColumnGossip = "dataColumnGossip",
+
+  /**
+   * This event signals that the chain has processed a beacon block gossip.
+   * TODO: Safe to extend the existing blockGossip route event?
+   */
+  signedBlockGossip = "signedBlockGossip",
 }
 
 export type HeadEventData = routes.events.EventData[routes.events.EventType.head];
@@ -47,6 +58,9 @@ export type IChainEvents = ApiEvents & {
 
   [ChainEvent.forkChoiceJustified]: (checkpoint: CheckpointWithHex) => void;
   [ChainEvent.forkChoiceFinalized]: (checkpoint: CheckpointWithHex) => void;
+
+  [ChainEvent.dataColumnGossip]: (sidecar: fulu.DataColumnSidecar) => void;
+  [ChainEvent.signedBlockGossip]: (block: SignedBeaconBlock) => void;
 };
 
 /**

--- a/packages/beacon-node/src/execution/engine/disabled.ts
+++ b/packages/beacon-node/src/execution/engine/disabled.ts
@@ -32,4 +32,8 @@ export class ExecutionEngineDisabled implements IExecutionEngine {
   getBlobs(): Promise<never> {
     throw Error("Execution engine disabled");
   }
+
+  getBlobsV2(): Promise<never> {
+    throw Error("Execution engine disabled");
+  }
 }

--- a/packages/beacon-node/src/execution/engine/disabled.ts
+++ b/packages/beacon-node/src/execution/engine/disabled.ts
@@ -32,8 +32,4 @@ export class ExecutionEngineDisabled implements IExecutionEngine {
   getBlobs(): Promise<never> {
     throw Error("Execution engine disabled");
   }
-
-  getBlobsV2(): Promise<never> {
-    throw Error("Execution engine disabled");
-  }
 }

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -497,7 +497,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     // https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#specification-3
     assertReqSizeLimit(versionedHashes.length, 128);
     const versionedHashesHex = versionedHashes.map(bytesToData);
-    const response = await this.rpc
+    let response = await this.rpc
       .fetchWithRetries<EngineApiRpcReturnTypes[typeof method], EngineApiRpcParamTypes[typeof method]>({
         method,
         params: [versionedHashesHex],
@@ -515,6 +515,15 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         }
         throw e;
       });
+
+    // handle nethermind buggy response
+    // see: https://discord.com/channels/595666850260713488/1293605631785304088/1298956894274060301
+    if (
+      method === "engine_getBlobsV1" &&
+      (response as unknown as {blobsAndProofs: EngineApiRpcReturnTypes[typeof method]}).blobsAndProofs !== undefined
+    ) {
+      response = (response as unknown as {blobsAndProofs: EngineApiRpcReturnTypes[typeof method]}).blobsAndProofs;
+    }
 
     // engine_getBlobsV2 does not return partial responses. It returns an empty array if any blob is not found
     const invalidLength =

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -2,6 +2,7 @@ import {Logger} from "@lodestar/logger";
 import {ForkName, ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ExecutionPayload, ExecutionRequests, Root, RootHex, Wei} from "@lodestar/types";
 import {BlobAndProof} from "@lodestar/types/deneb";
+import {BlobAndProofV2} from "@lodestar/types/fulu";
 import {strip0xPrefix} from "@lodestar/utils";
 import {
   ErrorJsonRpcResponse,
@@ -35,6 +36,7 @@ import {
   ExecutionPayloadBody,
   assertReqSizeLimit,
   deserializeBlobAndProofs,
+  deserializeBlobAndProofsV2,
   deserializeExecutionPayloadBody,
   parseExecutionPayload,
   serializeBeaconBlockRoot,
@@ -515,6 +517,61 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     }
 
     return response.map(deserializeBlobAndProofs);
+  }
+
+  async getBlobsV2(fork: ForkName, versionedHashes: VersionedHashes): Promise<BlobAndProofV2[]> {
+    if (ForkSeq[fork] < ForkSeq.fulu) {
+      throw Error(`engine_getBlobsV2 not available for fork=${fork}`);
+    }
+
+    // retry only after a day may be
+    const GETBLOBS_RETRY_TIMEOUT = 256 * 32 * 12;
+    const timeNow = Date.now() / 1000;
+    const timeSinceLastFail = timeNow - this.lastGetBlobsErrorTime;
+    if (timeSinceLastFail < GETBLOBS_RETRY_TIMEOUT) {
+      // do not try getblobs since it might not be available
+      this.logger.debug(
+        `disabled engine_getBlobsV2 api call since last failed < GETBLOBS_RETRY_TIMEOUT=${GETBLOBS_RETRY_TIMEOUT}`,
+        timeSinceLastFail
+      );
+      throw Error(
+        `engine_getBlobsV2 call recently failed timeSinceLastFail=${timeSinceLastFail} < GETBLOBS_RETRY_TIMEOUT=${GETBLOBS_RETRY_TIMEOUT}`
+      );
+    }
+
+    const method = "engine_getBlobsV2";
+    assertReqSizeLimit(versionedHashes.length, 128);
+    const versionedHashesHex = versionedHashes.map(bytesToData);
+    let response = await this.rpc
+      .fetchWithRetries<EngineApiRpcReturnTypes[typeof method], EngineApiRpcParamTypes[typeof method]>({
+        method,
+        params: [versionedHashesHex],
+      })
+      .catch((e) => {
+        if (e instanceof ErrorJsonRpcResponse && parseJsonRpcErrorCode(e.response.error.code) === "Method not found") {
+          this.lastGetBlobsErrorTime = timeNow;
+          this.logger.debug("disabling engine_getBlobsV2 api call since engine responded with method not availeble", {
+            retryTimeout: GETBLOBS_RETRY_TIMEOUT,
+          });
+        }
+        throw e;
+      });
+
+    // handle nethermind buggy response
+    // see: https://discord.com/channels/595666850260713488/1293605631785304088/1298956894274060301
+    if (
+      (response as unknown as {blobsAndProofs: EngineApiRpcReturnTypes[typeof method]}).blobsAndProofs !== undefined
+    ) {
+      response = (response as unknown as {blobsAndProofs: EngineApiRpcReturnTypes[typeof method]}).blobsAndProofs;
+    }
+
+    if (response.length > 0 && response.length !== versionedHashes.length) {
+      const error = `Invalid engine_getBlobsV2 response length=${response.length} versionedHashes=${versionedHashes.length}`;
+      this.logger.error(error);
+      throw Error(error);
+    }
+
+    return response.map(deserializeBlobAndProofsV2);
   }
 
   private async getClientVersion(clientVersion: ClientVersion): Promise<ClientVersion[]> {

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -542,7 +542,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const method = "engine_getBlobsV2";
     assertReqSizeLimit(versionedHashes.length, 128);
     const versionedHashesHex = versionedHashes.map(bytesToData);
-    let response = await this.rpc
+    const response = await this.rpc
       .fetchWithRetries<EngineApiRpcReturnTypes[typeof method], EngineApiRpcParamTypes[typeof method]>({
         method,
         params: [versionedHashesHex],
@@ -556,14 +556,6 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         }
         throw e;
       });
-
-    // handle nethermind buggy response
-    // see: https://discord.com/channels/595666850260713488/1293605631785304088/1298956894274060301
-    if (
-      (response as unknown as {blobsAndProofs: EngineApiRpcReturnTypes[typeof method]}).blobsAndProofs !== undefined
-    ) {
-      response = (response as unknown as {blobsAndProofs: EngineApiRpcReturnTypes[typeof method]}).blobsAndProofs;
-    }
 
     if (response.length > 0 && response.length !== versionedHashes.length) {
       const error = `Invalid engine_getBlobsV2 response length=${response.length} versionedHashes=${versionedHashes.length}`;

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -117,7 +117,8 @@ const getPayloadOpts: ReqOpts = {routeId: "getPayload"};
  */
 export class ExecutionEngineHttp implements IExecutionEngine {
   private logger: Logger;
-  private lastGetBlobsErrorTime = 0;
+  private lastGetBlobsV1ErrorTime = 0;
+  private lastGetBlobsV2ErrorTime = 0;
 
   // The default state is ONLINE, it will be updated to SYNCING once we receive the first payload
   // This assumption is better than the OFFLINE state, since we can't be sure if the EL is offline and being offline may trigger some notifications
@@ -476,17 +477,44 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   ): Promise<BlobAndProofV2[] | (BlobAndProof | null)[]> {
     const method = isForkPostFulu(fork) ? "engine_getBlobsV2" : "engine_getBlobsV1";
 
+    // retry only after a day may be
+    const GETBLOBS_RETRY_TIMEOUT = 256 * 32 * 12;
+    const timeNow = Date.now() / 1000;
+    const timeSinceLastFail =
+      timeNow - (isForkPostFulu(fork) ? this.lastGetBlobsV2ErrorTime : this.lastGetBlobsV1ErrorTime);
+    if (timeSinceLastFail < GETBLOBS_RETRY_TIMEOUT) {
+      // do not try getblobs since it might not be available
+      this.logger.debug(
+        `disabled ${method} api call since last failed < GETBLOBS_RETRY_TIMEOUT=${GETBLOBS_RETRY_TIMEOUT}`,
+        timeSinceLastFail
+      );
+      throw Error(
+        `${method} call recently failed timeSinceLastFail=${timeSinceLastFail} < GETBLOBS_RETRY_TIMEOUT=${GETBLOBS_RETRY_TIMEOUT}`
+      );
+    }
+
     // Clients must support at least 128 versionedHashes, so we avoid sending more
     // https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#specification-3
     assertReqSizeLimit(versionedHashes.length, 128);
     const versionedHashesHex = versionedHashes.map(bytesToData);
-    const response = await this.rpc.fetchWithRetries<
-      EngineApiRpcReturnTypes[typeof method],
-      EngineApiRpcParamTypes[typeof method]
-    >({
-      method,
-      params: [versionedHashesHex],
-    });
+    const response = await this.rpc
+      .fetchWithRetries<EngineApiRpcReturnTypes[typeof method], EngineApiRpcParamTypes[typeof method]>({
+        method,
+        params: [versionedHashesHex],
+      })
+      .catch((e) => {
+        if (e instanceof ErrorJsonRpcResponse && parseJsonRpcErrorCode(e.response.error.code) === "Method not found") {
+          if (isForkPostFulu(fork)) {
+            this.lastGetBlobsV2ErrorTime = timeNow;
+          } else {
+            this.lastGetBlobsV1ErrorTime = timeNow;
+          }
+          this.logger.debug(`disabling ${method} api call since engine responded with method not available`, {
+            retryTimeout: GETBLOBS_RETRY_TIMEOUT,
+          });
+        }
+        throw e;
+      });
 
     // engine_getBlobsV2 does not return partial responses. It returns an empty array if any blob is not found
     const invalidLength =

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -1,5 +1,5 @@
 import {Logger} from "@lodestar/logger";
-import {ForkName, ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkName, ForkPostFulu, ForkPreFulu, ForkSeq, isForkPostFulu, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ExecutionPayload, ExecutionRequests, Root, RootHex, Wei} from "@lodestar/types";
 import {BlobAndProof} from "@lodestar/types/deneb";
 import {BlobAndProofV2} from "@lodestar/types/fulu";
@@ -468,102 +468,42 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     return response.map(deserializeExecutionPayloadBody);
   }
 
-  async getBlobs(_fork: ForkName, versionedHashes: VersionedHashes): Promise<(BlobAndProof | null)[]> {
-    // retry only after a day may be
-    const GETBLOBS_RETRY_TIMEOUT = 256 * 32 * 12;
-    const timeNow = Date.now() / 1000;
-    const timeSinceLastFail = timeNow - this.lastGetBlobsErrorTime;
-    if (timeSinceLastFail < GETBLOBS_RETRY_TIMEOUT) {
-      // do not try getblobs since it might not be available
-      this.logger.debug(
-        `disabled engine_getBlobsV1 api call since last failed < GETBLOBS_RETRY_TIMEOUT=${GETBLOBS_RETRY_TIMEOUT}`,
-        timeSinceLastFail
-      );
-      throw Error(
-        `engine_getBlobsV1 call recently failed timeSinceLastFail=${timeSinceLastFail} < GETBLOBS_RETRY_TIMEOUT=${GETBLOBS_RETRY_TIMEOUT}`
-      );
-    }
+  async getBlobs(fork: ForkPostFulu, versionedHashes: VersionedHashes): Promise<BlobAndProofV2[]>;
+  async getBlobs(fork: ForkPreFulu, versionedHashes: VersionedHashes): Promise<(BlobAndProof | null)[]>;
+  async getBlobs(
+    fork: ForkName,
+    versionedHashes: VersionedHashes
+  ): Promise<BlobAndProofV2[] | (BlobAndProof | null)[]> {
+    const method = isForkPostFulu(fork) ? "engine_getBlobsV2" : "engine_getBlobsV1";
 
-    const method = "engine_getBlobsV1";
+    // Clients must support at least 128 versionedHashes, so we avoid sending more
+    // https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#specification-3
     assertReqSizeLimit(versionedHashes.length, 128);
     const versionedHashesHex = versionedHashes.map(bytesToData);
-    let response = await this.rpc
-      .fetchWithRetries<EngineApiRpcReturnTypes[typeof method], EngineApiRpcParamTypes[typeof method]>({
-        method,
-        params: [versionedHashesHex],
-      })
-      .catch((e) => {
-        if (e instanceof ErrorJsonRpcResponse && parseJsonRpcErrorCode(e.response.error.code) === "Method not found") {
-          this.lastGetBlobsErrorTime = timeNow;
-          this.logger.debug("disabling engine_getBlobsV1 api call since engine responded with method not availeble", {
-            retryTimeout: GETBLOBS_RETRY_TIMEOUT,
-          });
-        }
-        throw e;
-      });
+    const response = await this.rpc.fetchWithRetries<
+      EngineApiRpcReturnTypes[typeof method],
+      EngineApiRpcParamTypes[typeof method]
+    >({
+      method,
+      params: [versionedHashesHex],
+    });
 
-    // handle nethermind buggy response
-    // see: https://discord.com/channels/595666850260713488/1293605631785304088/1298956894274060301
-    if (
-      (response as unknown as {blobsAndProofs: EngineApiRpcReturnTypes[typeof method]}).blobsAndProofs !== undefined
-    ) {
-      response = (response as unknown as {blobsAndProofs: EngineApiRpcReturnTypes[typeof method]}).blobsAndProofs;
-    }
+    // engine_getBlobsV2 does not return partial responses. It returns an empty array if any blob is not found
+    const invalidLength =
+      method === "engine_getBlobsV2"
+        ? response.length > 0 && response.length !== versionedHashes.length
+        : response.length !== versionedHashes.length;
 
-    if (response.length !== versionedHashes.length) {
-      const error = `Invalid engine_getBlobsV1 response length=${response.length} versionedHashes=${versionedHashes.length}`;
+    if (invalidLength) {
+      const error = `Invalid ${method} response length=${response.length} versionedHashes=${versionedHashes.length}`;
       this.logger.error(error);
       throw Error(error);
     }
 
-    return response.map(deserializeBlobAndProofs);
-  }
-
-  async getBlobsV2(fork: ForkName, versionedHashes: VersionedHashes): Promise<BlobAndProofV2[]> {
-    if (ForkSeq[fork] < ForkSeq.fulu) {
-      throw Error(`engine_getBlobsV2 not available for fork=${fork}`);
-    }
-
-    // retry only after a day may be
-    const GETBLOBS_RETRY_TIMEOUT = 256 * 32 * 12;
-    const timeNow = Date.now() / 1000;
-    const timeSinceLastFail = timeNow - this.lastGetBlobsErrorTime;
-    if (timeSinceLastFail < GETBLOBS_RETRY_TIMEOUT) {
-      // do not try getblobs since it might not be available
-      this.logger.debug(
-        `disabled engine_getBlobsV2 api call since last failed < GETBLOBS_RETRY_TIMEOUT=${GETBLOBS_RETRY_TIMEOUT}`,
-        timeSinceLastFail
-      );
-      throw Error(
-        `engine_getBlobsV2 call recently failed timeSinceLastFail=${timeSinceLastFail} < GETBLOBS_RETRY_TIMEOUT=${GETBLOBS_RETRY_TIMEOUT}`
-      );
-    }
-
-    const method = "engine_getBlobsV2";
-    assertReqSizeLimit(versionedHashes.length, 128);
-    const versionedHashesHex = versionedHashes.map(bytesToData);
-    const response = await this.rpc
-      .fetchWithRetries<EngineApiRpcReturnTypes[typeof method], EngineApiRpcParamTypes[typeof method]>({
-        method,
-        params: [versionedHashesHex],
-      })
-      .catch((e) => {
-        if (e instanceof ErrorJsonRpcResponse && parseJsonRpcErrorCode(e.response.error.code) === "Method not found") {
-          this.lastGetBlobsErrorTime = timeNow;
-          this.logger.debug("disabling engine_getBlobsV2 api call since engine responded with method not availeble", {
-            retryTimeout: GETBLOBS_RETRY_TIMEOUT,
-          });
-        }
-        throw e;
-      });
-
-    if (response.length > 0 && response.length !== versionedHashes.length) {
-      const error = `Invalid engine_getBlobsV2 response length=${response.length} versionedHashes=${versionedHashes.length}`;
-      this.logger.error(error);
-      throw Error(error);
-    }
-
-    return response.map(deserializeBlobAndProofsV2);
+    // engine_getBlobsV2 returns a list of cell proofs per blob, whereas engine_getBlobsV1 returns one proof per blob
+    return method === "engine_getBlobsV2"
+      ? (response as EngineApiRpcReturnTypes[typeof method]).map(deserializeBlobAndProofsV2)
+      : (response as EngineApiRpcReturnTypes[typeof method]).map(deserializeBlobAndProofs);
   }
 
   private async getClientVersion(clientVersion: ClientVersion): Promise<ClientVersion[]> {

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -1,4 +1,11 @@
-import {CONSOLIDATION_REQUEST_TYPE, DEPOSIT_REQUEST_TYPE, ForkName, WITHDRAWAL_REQUEST_TYPE} from "@lodestar/params";
+import {
+  CONSOLIDATION_REQUEST_TYPE,
+  DEPOSIT_REQUEST_TYPE,
+  ForkName,
+  ForkPostFulu,
+  ForkPreFulu,
+  WITHDRAWAL_REQUEST_TYPE,
+} from "@lodestar/params";
 import {ExecutionPayload, ExecutionRequests, Root, RootHex, Wei, capella} from "@lodestar/types";
 import {Blob, BlobAndProof, KZGCommitment, KZGProof} from "@lodestar/types/deneb";
 import {BlobAndProofV2} from "@lodestar/types/fulu";
@@ -190,7 +197,6 @@ export interface IExecutionEngine {
 
   getPayloadBodiesByRange(fork: ForkName, start: number, count: number): Promise<(ExecutionPayloadBody | null)[]>;
 
-  getBlobs(fork: ForkName, versionedHashes: VersionedHashes): Promise<(BlobAndProof | null)[]>;
-
-  getBlobsV2(fork: ForkName, versionedHashes: VersionedHashes): Promise<BlobAndProofV2[]>;
+  getBlobs(fork: ForkPostFulu, versionedHashes: VersionedHashes): Promise<BlobAndProofV2[]>;
+  getBlobs(fork: ForkPreFulu, versionedHashes: VersionedHashes): Promise<(BlobAndProof | null)[]>;
 }

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -1,6 +1,7 @@
 import {CONSOLIDATION_REQUEST_TYPE, DEPOSIT_REQUEST_TYPE, ForkName, WITHDRAWAL_REQUEST_TYPE} from "@lodestar/params";
 import {ExecutionPayload, ExecutionRequests, Root, RootHex, Wei, capella} from "@lodestar/types";
 import {Blob, BlobAndProof, KZGCommitment, KZGProof} from "@lodestar/types/deneb";
+import {BlobAndProofV2} from "@lodestar/types/fulu";
 
 import {DATA} from "../../eth1/provider/utils.js";
 import {PayloadId, PayloadIdCache, WithdrawalV1} from "./payloadIdCache.js";
@@ -190,4 +191,6 @@ export interface IExecutionEngine {
   getPayloadBodiesByRange(fork: ForkName, start: number, count: number): Promise<(ExecutionPayloadBody | null)[]>;
 
   getBlobs(fork: ForkName, versionedHashes: VersionedHashes): Promise<(BlobAndProof | null)[]>;
+
+  getBlobsV2(fork: ForkName, versionedHashes: VersionedHashes): Promise<BlobAndProofV2[]>;
 }

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -100,6 +100,7 @@ export class ExecutionEngineMockBackend implements JsonRpcBackend {
       engine_getPayloadBodiesByRangeV1: this.getPayloadBodiesByRange.bind(this),
       engine_getClientVersionV1: this.getClientVersionV1.bind(this),
       engine_getBlobsV1: this.getBlobs.bind(this),
+      engine_getBlobsV2: this.getBlobsV2.bind(this),
     };
   }
 
@@ -402,6 +403,12 @@ export class ExecutionEngineMockBackend implements JsonRpcBackend {
     versionedHashes: EngineApiRpcParamTypes["engine_getBlobsV1"][0]
   ): EngineApiRpcReturnTypes["engine_getBlobsV1"] {
     return versionedHashes.map((_vh) => null);
+  }
+
+  private getBlobsV2(
+    _versionedHashes: EngineApiRpcParamTypes["engine_getBlobsV2"][0]
+  ): EngineApiRpcReturnTypes["engine_getBlobsV2"] {
+    return [];
   }
 
   private timestampToFork(timestamp: number): ForkPostBellatrix {

--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -10,6 +10,7 @@ import {
 } from "@lodestar/params";
 import {ExecutionPayload, ExecutionRequests, Root, Wei, bellatrix, capella, deneb, electra, ssz} from "@lodestar/types";
 import {BlobAndProof} from "@lodestar/types/deneb";
+import {BlobAndProofV2} from "@lodestar/types/fulu";
 
 import {
   DATA,
@@ -80,6 +81,7 @@ export type EngineApiRpcParamTypes = {
   engine_getClientVersionV1: [ClientVersionRpc];
 
   engine_getBlobsV1: [DATA[]];
+  engine_getBlobsV2: [DATA[]];
 };
 
 export type PayloadStatus = {
@@ -123,7 +125,8 @@ export type EngineApiRpcReturnTypes = {
 
   engine_getClientVersionV1: ClientVersionRpc[];
 
-  engine_getBlobsV1: (BlobAndProofRpc | null)[];
+  engine_getBlobsV1: (BlobAndProofV1Rpc | null)[];
+  engine_getBlobsV2: BlobAndProofV2Rpc[];
 };
 
 type ExecutionPayloadRpcWithValue = {
@@ -186,9 +189,14 @@ export type DepositRequestsRpc = DATA;
 export type WithdrawalRequestsRpc = DATA;
 export type ConsolidationRequestsRpc = DATA;
 
-export type BlobAndProofRpc = {
+export type BlobAndProofV1Rpc = {
   blob: DATA;
   proof: DATA;
+};
+
+export type BlobAndProofV2Rpc = {
+  blob: DATA;
+  proofs: DATA[];
 };
 
 export type VersionedHashesRpc = DATA[];
@@ -554,13 +562,20 @@ export function serializeExecutionPayloadBody(data: ExecutionPayloadBody | null)
     : null;
 }
 
-export function deserializeBlobAndProofs(data: BlobAndProofRpc | null): BlobAndProof | null {
+export function deserializeBlobAndProofs(data: BlobAndProofV1Rpc | null): BlobAndProof | null {
   return data
     ? {
         blob: dataToBytes(data.blob, BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB),
         proof: dataToBytes(data.proof, 48),
       }
     : null;
+}
+
+export function deserializeBlobAndProofsV2(data: BlobAndProofV2Rpc): BlobAndProofV2 {
+  return {
+    blob: dataToBytes(data.blob, BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB),
+    proofs: data.proofs.map((proof) => dataToBytes(proof, 48)),
+  };
 }
 
 export function assertReqSizeLimit(blockHashesReqCount: number, count: number): void {

--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -125,7 +125,7 @@ export type EngineApiRpcReturnTypes = {
 
   engine_getClientVersionV1: ClientVersionRpc[];
 
-  engine_getBlobsV1: (BlobAndProofV1Rpc | null)[];
+  engine_getBlobsV1: (BlobAndProofRpc | null)[];
   engine_getBlobsV2: BlobAndProofV2Rpc[];
 };
 
@@ -189,7 +189,7 @@ export type DepositRequestsRpc = DATA;
 export type WithdrawalRequestsRpc = DATA;
 export type ConsolidationRequestsRpc = DATA;
 
-export type BlobAndProofV1Rpc = {
+export type BlobAndProofRpc = {
   blob: DATA;
   proof: DATA;
 };
@@ -562,7 +562,7 @@ export function serializeExecutionPayloadBody(data: ExecutionPayloadBody | null)
     : null;
 }
 
-export function deserializeBlobAndProofs(data: BlobAndProofV1Rpc | null): BlobAndProof | null {
+export function deserializeBlobAndProofs(data: BlobAndProofRpc | null): BlobAndProof | null {
   return data
     ? {
         blob: dataToBytes(data.blob, BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB),

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -74,6 +74,7 @@ import {sszDeserialize} from "../gossip/topic.js";
 import {INetwork} from "../interface.js";
 import {PeerAction} from "../peers/index.js";
 import {AggregatorTracker} from "./aggregatorTracker.js";
+import {ChainEvent} from "../../chain/emitter.js";
 
 /**
  * Gossip handler options as part of network options
@@ -177,6 +178,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       logger.debug("Validated gossip block", {...logCtx, recvToValidation, validationTime});
 
       chain.emitter.emit(routes.events.EventType.blockGossip, {slot, block: blockRootHex});
+      chain.emitter.emit(ChainEvent.signedBlockGossip, signedBlock);
 
       return blockInput;
     } catch (e) {
@@ -309,6 +311,8 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         recvToValidation,
         validationTime,
       });
+
+      chain.emitter.emit(ChainEvent.dataColumnGossip, dataColumnSidecar);
 
       return blockInput;
     } catch (e) {

--- a/packages/beacon-node/src/sync/reconstruction/columnReconstructor.ts
+++ b/packages/beacon-node/src/sync/reconstruction/columnReconstructor.ts
@@ -1,0 +1,137 @@
+import {toHexString} from "@chainsafe/ssz";
+import {isForkPostFulu} from "@lodestar/params";
+import {RootHex, SignedBeaconBlock, fulu} from "@lodestar/types";
+import {pruneSetToMax} from "@lodestar/utils";
+import {CustodyConfig} from "../../util/dataColumns.js";
+import {GossipedInputType} from "../../chain/blocks/types.js";
+import {IExecutionEngine} from "../../execution/index.js";
+import {
+  getCellsAndProofs,
+  getDataColumnSidecarsFromBlock,
+  getDataColumnSidecarsFromColumnSidecar,
+  kzgCommitmentToVersionedHash,
+} from "../../util/blobs.js";
+import {INetwork} from "../../network/index.js";
+import {SeenGossipBlockInput} from "../../chain/seenCache/seenGossipBlockInput.js";
+import {IBeaconChain} from "../../chain/interface.js";
+
+type ColumnReconstructorBlockInput =
+  | {type: GossipedInputType.block; signedBlock: SignedBeaconBlock}
+  | {
+      type: GossipedInputType.dataColumn;
+      dataColumnSidecar: fulu.DataColumnSidecar;
+      dataColumnBytes: Uint8Array | null;
+    };
+
+const MAX_GOSSIPINPUT_CACHE = 5;
+
+export class ColumnReconstructor {
+  private readonly blockInputCache = new Set<RootHex>();
+  private readonly custodyConfig: CustodyConfig;
+  private readonly executionEngine: IExecutionEngine;
+  private readonly network: INetwork;
+  private readonly seenGossipBlockInput: SeenGossipBlockInput;
+  private readonly chain: IBeaconChain;
+
+  constructor(chain: IBeaconChain, network: INetwork) {
+    this.chain = chain;
+    this.custodyConfig = chain.custodyConfig;
+    this.executionEngine = chain.executionEngine;
+    this.network = network;
+    this.seenGossipBlockInput = chain.seenGossipBlockInput;
+  }
+
+  prune(): void {
+    pruneSetToMax(this.blockInputCache, MAX_GOSSIPINPUT_CACHE);
+  }
+
+  hasBlock(blockRoot: RootHex): boolean {
+    return this.blockInputCache.has(blockRoot);
+  }
+
+  async reconstructColumns(input: ColumnReconstructorBlockInput): Promise<void> {
+    const config = this.chain.config;
+    const slot =
+      input.type === GossipedInputType.block
+        ? input.signedBlock.message.slot
+        : input.dataColumnSidecar.signedBlockHeader.message.slot;
+    const fork = config.getForkName(slot);
+
+    // Only reconstruct columns for post-Fulu forks
+    if (!isForkPostFulu(fork)) {
+      return;
+    }
+
+    let blockHex: RootHex;
+    if (input.type === GossipedInputType.block) {
+      blockHex = toHexString(config.getForkTypes(slot).BeaconBlock.hashTreeRoot(input.signedBlock.message));
+    } else if (input.type === GossipedInputType.dataColumn) {
+      blockHex = toHexString(
+        config.getForkTypes(slot).BeaconBlockHeader.hashTreeRoot(input.dataColumnSidecar.signedBlockHeader.message)
+      );
+    } else {
+      throw new Error("Invalid gossipedInput type");
+    }
+
+    if (this.blockInputCache.has(blockHex)) {
+      return;
+    }
+
+    // Store the block in cache
+    this.blockInputCache.add(blockHex);
+
+    // Process KZG commitments into versioned hashes
+    let versionedHashes: Uint8Array[];
+
+    if (input.type === GossipedInputType.block) {
+      const block = input.signedBlock as fulu.SignedBeaconBlock;
+      versionedHashes = block.message.body.blobKzgCommitments.map(kzgCommitmentToVersionedHash);
+    } else if (input.type === GossipedInputType.dataColumn) {
+      versionedHashes = input.dataColumnSidecar.kzgCommitments.map(kzgCommitmentToVersionedHash);
+    } else {
+      throw new Error("Invalid gossipedInput type");
+    }
+
+    if (versionedHashes.length === 0) {
+      return;
+    }
+
+    // Get blobs from execution engine
+    const blobs = await this.executionEngine.getBlobs(fork, versionedHashes);
+
+    // Execution engine was unable to find one or more blobs
+    if (blobs.length === 0) {
+      return;
+    }
+
+    let dataColumnSidecars: fulu.DataColumnSidecars;
+    const cellsAndProofs = getCellsAndProofs(blobs);
+    if (input.type === GossipedInputType.block) {
+      dataColumnSidecars = getDataColumnSidecarsFromBlock(
+        config,
+        input.signedBlock as fulu.SignedBeaconBlock,
+        cellsAndProofs
+      );
+    } else if (input.type === GossipedInputType.dataColumn) {
+      dataColumnSidecars = getDataColumnSidecarsFromColumnSidecar(input.dataColumnSidecar, cellsAndProofs);
+    } else {
+      throw new Error("Invalid gossipedInput type");
+    }
+
+    // TODO: re-gossip the sidecars to subscribed subnets
+
+    for (const sidecar of dataColumnSidecars) {
+      this.seenGossipBlockInput.getGossipBlockInput(
+        config,
+        {
+          type: GossipedInputType.dataColumn,
+          dataColumnSidecar: sidecar,
+          // TODO: figure out what to use here
+          dataColumnBytes: null,
+        },
+        // TODO: Pass in metrics. Should this use a different availability source?
+        null
+      );
+    }
+  }
+}

--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -1,7 +1,7 @@
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {Slot} from "@lodestar/types";
+import {fulu, SignedBeaconBlock, Slot} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
-import {IBeaconChain} from "../chain/index.js";
+import {ChainEvent, IBeaconChain} from "../chain/index.js";
 import {GENESIS_SLOT} from "../constants/constants.js";
 import {ExecutionEngineState} from "../execution/index.js";
 import {Metrics} from "../metrics/index.js";
@@ -15,6 +15,8 @@ import {SyncOptions} from "./options.js";
 import {RangeSync, RangeSyncEvent, RangeSyncStatus} from "./range/range.js";
 import {UnknownBlockSync} from "./unknownBlock.js";
 import {PeerSyncType, getPeerSyncType, peerSyncTypes} from "./utils/remoteSyncType.js";
+import {ColumnReconstructor} from "./reconstruction/columnReconstructor.js";
+import {GossipedInputType} from "../chain/blocks/types.js";
 
 export class BeaconSync implements IBeaconSync {
   private readonly logger: Logger;
@@ -25,6 +27,7 @@ export class BeaconSync implements IBeaconSync {
 
   private readonly rangeSync: RangeSync;
   private readonly unknownBlockSync: UnknownBlockSync;
+  private readonly columnReconstructor: ColumnReconstructor;
 
   /** For metrics only */
   private readonly peerSyncType = new Map<string, PeerSyncType>();
@@ -39,7 +42,12 @@ export class BeaconSync implements IBeaconSync {
     this.logger = logger;
     this.rangeSync = new RangeSync(modules, opts);
     this.unknownBlockSync = new UnknownBlockSync(config, network, chain, logger, metrics, opts);
+    this.columnReconstructor = new ColumnReconstructor(chain, network);
     this.slotImportTolerance = opts.slotImportTolerance ?? SLOTS_PER_EPOCH;
+
+    // Subscribe to events that trigger column reconstruction
+    this.chain.emitter.on(ChainEvent.dataColumnGossip, this.dataColumnGossip);
+    this.chain.emitter.on(ChainEvent.signedBlockGossip, this.signedBlockGossip);
 
     // Subscribe to RangeSync completing a SyncChain and recompute sync state
     if (!opts.disableRangeSync) {
@@ -79,6 +87,8 @@ export class BeaconSync implements IBeaconSync {
   }
 
   close(): void {
+    this.chain.emitter.off(ChainEvent.dataColumnGossip, this.dataColumnGossip);
+    this.chain.emitter.off(ChainEvent.signedBlockGossip, this.signedBlockGossip);
     this.network.events.off(NetworkEvent.peerConnected, this.addPeer);
     this.network.events.off(NetworkEvent.peerDisconnected, this.removePeer);
     this.chain.clock.off(ClockEvent.epoch, this.onClockEpoch);
@@ -207,6 +217,21 @@ export class BeaconSync implements IBeaconSync {
     this.rangeSync.removePeer(data.peer);
 
     this.peerSyncType.delete(data.peer.toString());
+  };
+
+  private dataColumnGossip = (dataColumnSidecar: fulu.DataColumnSidecar): void => {
+    this.columnReconstructor.reconstructColumns({
+      type: GossipedInputType.dataColumn,
+      dataColumnSidecar,
+      dataColumnBytes: null,
+    });
+  };
+
+  private signedBlockGossip = (block: SignedBeaconBlock): void => {
+    this.columnReconstructor.reconstructColumns({
+      type: GossipedInputType.block,
+      signedBlock: block,
+    });
   };
 
   /**

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -11,7 +11,15 @@ import {
   VERSIONED_HASH_VERSION_KZG,
 } from "@lodestar/params";
 import {signedBlockToSignedHeader} from "@lodestar/state-transition";
-import {BeaconBlockBody, SSZTypesFor, SignedBeaconBlock, deneb, fulu, ssz} from "@lodestar/types";
+import {
+  BeaconBlockBody,
+  SSZTypesFor,
+  SignedBeaconBlock,
+  SignedBeaconBlockHeader,
+  deneb,
+  fulu,
+  ssz,
+} from "@lodestar/types";
 import {ckzg} from "./kzg.js";
 
 type VersionHash = Uint8Array;
@@ -103,4 +111,96 @@ export function computeDataColumnSidecars(
       kzgCommitmentsInclusionProof,
     };
   });
+}
+
+/**
+ * Given a blob and cell proofs, computes the cells for each blob and combines them with the proofs.
+ * Similar to the computeMatrix function described below.
+ *
+ * SPEC FUNCTION (note: spec currently computes proofs, but we already have them)
+ * https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#compute_matrix
+ */
+export function getCellsAndProofs(blobs: fulu.BlobAndProofV2[]): [Uint8Array[], Uint8Array[]][] {
+  return blobs.map((blob) => {
+    const cells = ckzg.computeCells(blob.blob);
+    const proofs = blob.proofs;
+    return [cells, proofs];
+  });
+}
+
+/**
+ * Given a signed block header and the commitments, inclusion proof, cells/proofs associated with
+ * each blob in the block, assemble the sidecars which can be distributed to peers.
+ *
+ * SPEC FUNCTION
+ * https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/validator.md#get_data_column_sidecars
+ */
+export function getDataColumnSidecars(
+  signedBlockHeader: SignedBeaconBlockHeader,
+  kzgCommitments: deneb.KZGCommitment[],
+  kzgCommitmentsInclusionProof: fulu.KzgCommitmentsInclusionProof,
+  cellsAndKzgProofs: [Uint8Array[], Uint8Array[]][]
+): fulu.DataColumnSidecars {
+  if (cellsAndKzgProofs.length !== kzgCommitments.length) {
+    throw Error("Invalid cellsAndKzgProofs length for getDataColumnSidecars");
+  }
+
+  const sidecars: fulu.DataColumnSidecars = [];
+  for (let columnIndex = 0; columnIndex < NUMBER_OF_COLUMNS; columnIndex++) {
+    const columnCells = [];
+    const columnProofs = [];
+    for (const [cells, proofs] of cellsAndKzgProofs) {
+      columnCells.push(cells[columnIndex]);
+      columnProofs.push(proofs[columnIndex]);
+    }
+    sidecars.push({
+      index: columnIndex,
+      column: columnCells,
+      kzgCommitments,
+      kzgProofs: columnProofs,
+      signedBlockHeader,
+      kzgCommitmentsInclusionProof,
+    });
+  }
+  return sidecars;
+}
+
+/**
+ * Given a signed block and the cells/proofs associated with each blob in the
+ * block, assemble the sidecars which can be distributed to peers.
+ *
+ * SPEC FUNCTION
+ * https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/validator.md#get_data_column_sidecars_from_block
+ */
+export function getDataColumnSidecarsFromBlock(
+  config: ChainForkConfig,
+  signedBlock: fulu.SignedBeaconBlock,
+  cellsAndKzgProofs: [Uint8Array[], Uint8Array[]][]
+): fulu.DataColumnSidecars {
+  const blobKzgCommitments = (signedBlock as deneb.SignedBeaconBlock).message.body.blobKzgCommitments;
+  const fork = config.getForkName(signedBlock.message.slot);
+  const signedBlockHeader = signedBlockToSignedHeader(config, signedBlock);
+
+  const kzgCommitmentsInclusionProof = computeKzgCommitmentsInclusionProof(fork, signedBlock.message.body);
+
+  return getDataColumnSidecars(signedBlockHeader, blobKzgCommitments, kzgCommitmentsInclusionProof, cellsAndKzgProofs);
+}
+
+/**
+ * Given a DataColumnSidecar and the cells/proofs associated with each blob corresponding
+ * to the commitments it contains, assemble all sidecars for distribution to peers.
+ *
+ * SPEC FUNCTION
+ * https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/validator.md#get_data_column_sidecars_from_column_sidecar
+ */
+export function getDataColumnSidecarsFromColumnSidecar(
+  sidecar: fulu.DataColumnSidecar,
+  cellsAndKzgProofs: [Uint8Array[], Uint8Array[]][]
+): fulu.DataColumnSidecars {
+  return getDataColumnSidecars(
+    sidecar.signedBlockHeader,
+    sidecar.kzgCommitments,
+    sidecar.kzgCommitmentsInclusionProof,
+    cellsAndKzgProofs
+  );
 }

--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -13,6 +13,7 @@ export let ckzg: {
   verifyKzgProof(commitmentBytes: Uint8Array, zBytes: Uint8Array, yBytes: Uint8Array, proofBytes: Uint8Array): boolean;
   verifyBlobKzgProof(blob: Uint8Array, commitment: Uint8Array, proof: Uint8Array): boolean;
   verifyBlobKzgProofBatch(blobs: Uint8Array[], expectedKzgCommitments: Uint8Array[], kzgProofs: Uint8Array[]): boolean;
+  computeCells(blob: Uint8Array): Uint8Array[];
   computeCellsAndKzgProofs(blob: Uint8Array): [Uint8Array[], Uint8Array[]];
   recoverCellsAndKzgProofs(cellIndices: number[], cells: Uint8Array[]): [Uint8Array[], Uint8Array[]];
   verifyCellKzgProofBatch(
@@ -29,6 +30,7 @@ export let ckzg: {
   verifyKzgProof: ckzgNotLoaded,
   verifyBlobKzgProof: ckzgNotLoaded,
   verifyBlobKzgProofBatch: ckzgNotLoaded,
+  computeCells: ckzgNotLoaded,
   computeCellsAndKzgProofs: ckzgNotLoaded,
   recoverCellsAndKzgProofs: ckzgNotLoaded,
   verifyCellKzgProofBatch: ckzgNotLoaded,

--- a/packages/types/src/fulu/sszTypes.ts
+++ b/packages/types/src/fulu/sszTypes.ts
@@ -16,6 +16,9 @@ import {ssz as primitiveSsz} from "../primitive/index.js";
 
 const {BLSSignature, Root, ColumnIndex, RowIndex, Bytes32, Slot, UintNum64} = primitiveSsz;
 
+export const KZGProof = denebSsz.KZGProof;
+export const Blob = denebSsz.Blob;
+
 export const Metadata = new ContainerType(
   {
     ...altariSsz.Metadata.fields,

--- a/packages/types/src/fulu/types.ts
+++ b/packages/types/src/fulu/types.ts
@@ -1,6 +1,9 @@
 import {ValueOf} from "@chainsafe/ssz";
 import * as ssz from "./sszTypes.js";
 
+export type KZGProof = ValueOf<typeof ssz.KZGProof>;
+export type Blob = ValueOf<typeof ssz.Blob>;
+
 export type Metadata = ValueOf<typeof ssz.Metadata>;
 
 export type Cell = ValueOf<typeof ssz.Cell>;
@@ -44,3 +47,7 @@ export type LightClientStore = ValueOf<typeof ssz.LightClientStore>;
 export type BlockContents = ValueOf<typeof ssz.BlockContents>;
 export type SignedBlockContents = ValueOf<typeof ssz.SignedBlockContents>;
 export type Contents = Omit<BlockContents, "block">;
+export type BlobAndProofV2 = {
+  blob: Blob;
+  proofs: KZGProof[];
+};


### PR DESCRIPTION
**Motivation**

Add support for [distributed blob publishing](https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/p2p-interface.md#distributed-blob-publishing-using-blobs-retrieved-from-local-execution-layer-client) (When a block or first data column for a block is received, fetch blobs from EL to reconstruct columns, then publish columns to the network).

This is still WIP, particularly I still need to write the network re-publishing. But wanted to get some feedback on the architecture since it has to interact across gossip handlers, network, and execution engine.

Depends on #7675 -- the last commit contains changes from this branch.

Fixes #7638

**Description**

* Adds a ColumnReconstructor to Sync that takes a chain and a network
* Adds new chain events for dataColumnGossip and blockGossip
* When either event is fired and it's the first time a block root is seen, call engine_getBlobsV2 to fetch all blobs/cell proofs in the block.
* If received, add them to `seenGossipBlockInput`.

TODOs are mentioned in the code.

